### PR TITLE
Syscall arg and test printf

### DIFF
--- a/sys/kern/init_sysent.c
+++ b/sys/kern/init_sysent.c
@@ -1,4 +1,4 @@
-/* $NetBSD: init_sysent.c,v 1.331 2020/04/26 19:16:36 thorpej Exp $ */
+/* $NetBSD$ */
 
 /*
  * System call switch table.
@@ -8,7 +8,7 @@
  */
 
 #include <sys/cdefs.h>
-__KERNEL_RCSID(0, "$NetBSD: init_sysent.c,v 1.331 2020/04/26 19:16:36 thorpej Exp $");
+__KERNEL_RCSID(0, "$NetBSD$");
 
 #ifdef _KERNEL_OPT
 #include "opt_modular.h"

--- a/sys/kern/kern_exec.c
+++ b/sys/kern/kern_exec.c
@@ -2458,6 +2458,9 @@ do_posix_spawn(struct lwp *l1, pid_t *pid_res, bool *child_ok, const char *path,
 
 	p1 = l1->l_proc;
 
+	/* Test Print for Build */
+	printf("do_posix_spawn called!\n");
+
 	/* Allocate and init spawn_data */
 	spawn_data = kmem_zalloc(sizeof(*spawn_data), KM_SLEEP);
 	spawn_data->sed_refcnt = 1; /* only parent so far */

--- a/sys/kern/syscalls.c
+++ b/sys/kern/syscalls.c
@@ -1,4 +1,4 @@
-/* $NetBSD: syscalls.c,v 1.319 2020/04/26 19:16:36 thorpej Exp $ */
+/* $NetBSD$ */
 
 /*
  * System call names.
@@ -8,7 +8,7 @@
  */
 
 #include <sys/cdefs.h>
-__KERNEL_RCSID(0, "$NetBSD: syscalls.c,v 1.319 2020/04/26 19:16:36 thorpej Exp $");
+__KERNEL_RCSID(0, "$NetBSD$");
 
 #if defined(_KERNEL_OPT)
 #ifdef _KERNEL_OPT

--- a/sys/kern/syscalls.master
+++ b/sys/kern/syscalls.master
@@ -990,6 +990,7 @@
 474	NOERR		{ int|sys||posix_spawn(pid_t *pid, const char *path, \
 			    const struct posix_spawn_file_actions *file_actions, \
 			    const struct posix_spawnattr *attrp, \
+				const char *wd, \
 			    char *const *argv, char *const *envp); }
 475	STD	RUMP	{ int|sys||recvmmsg(int s, struct mmsghdr *mmsg, \
 			    unsigned int vlen, unsigned int flags, \

--- a/sys/kern/syscalls_autoload.c
+++ b/sys/kern/syscalls_autoload.c
@@ -1,4 +1,4 @@
-/* $NetBSD: syscalls_autoload.c,v 1.36 2020/04/26 19:16:36 thorpej Exp $ */
+/* $NetBSD$ */
 
 /*
  * System call autoload table.
@@ -8,7 +8,7 @@
  */
 
 #include <sys/cdefs.h>
-__KERNEL_RCSID(0, "$NetBSD: syscalls_autoload.c,v 1.36 2020/04/26 19:16:36 thorpej Exp $");
+__KERNEL_RCSID(0, "$NetBSD$");
 
 #ifdef _KERNEL_OPT
 #include "opt_modular.h"

--- a/sys/kern/systrace_args.c
+++ b/sys/kern/systrace_args.c
@@ -1,4 +1,4 @@
-/* $NetBSD: systrace_args.c,v 1.38 2020/04/26 19:16:36 thorpej Exp $ */
+/* $NetBSD$ */
 
 /*
  * System call argument to DTrace register array converstion.
@@ -3605,9 +3605,10 @@ systrace_args(register_t sysnum, const void *params, uintptr_t *uarg, size_t *n_
 		uarg[1] = (intptr_t) SCARG(p, path); /* const char * */
 		uarg[2] = (intptr_t) SCARG(p, file_actions); /* const struct posix_spawn_file_actions * */
 		uarg[3] = (intptr_t) SCARG(p, attrp); /* const struct posix_spawnattr * */
-		uarg[4] = (intptr_t) SCARG(p, argv); /* char *const * */
-		uarg[5] = (intptr_t) SCARG(p, envp); /* char *const * */
-		*n_args = 6;
+		uarg[4] = (intptr_t) SCARG(p, wd); /* const char * */
+		uarg[5] = (intptr_t) SCARG(p, argv); /* char *const * */
+		uarg[6] = (intptr_t) SCARG(p, envp); /* char *const * */
+		*n_args = 7;
 		break;
 	}
 	/* sys_recvmmsg */
@@ -9826,9 +9827,12 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "const struct posix_spawnattr *";
 			break;
 		case 4:
-			p = "char *const *";
+			p = "const char *";
 			break;
 		case 5:
+			p = "char *const *";
+			break;
+		case 6:
 			p = "char *const *";
 			break;
 		default:

--- a/sys/rump/include/rump/rump_syscalls.h
+++ b/sys/rump/include/rump/rump_syscalls.h
@@ -1,4 +1,4 @@
-/* $NetBSD: rump_syscalls.h,v 1.118 2020/04/26 19:16:36 thorpej Exp $ */
+/* $NetBSD$ */
 
 /*
  * System call protos in rump namespace.

--- a/sys/rump/librump/rumpkern/rump_syscalls.c
+++ b/sys/rump/librump/rumpkern/rump_syscalls.c
@@ -1,4 +1,4 @@
-/* $NetBSD: rump_syscalls.c,v 1.149 2020/04/26 19:16:36 thorpej Exp $ */
+/* $NetBSD$ */
 
 /*
  * System call vector and marshalling for rump.
@@ -15,7 +15,7 @@
 
 #ifdef __NetBSD__
 #include <sys/cdefs.h>
-__KERNEL_RCSID(0, "$NetBSD: rump_syscalls.c,v 1.149 2020/04/26 19:16:36 thorpej Exp $");
+__KERNEL_RCSID(0, "$NetBSD$");
 
 #include <sys/fstypes.h>
 #include <sys/proc.h>

--- a/sys/sys/syscall.h
+++ b/sys/sys/syscall.h
@@ -1,4 +1,4 @@
-/* $NetBSD: syscall.h,v 1.313 2020/04/26 19:16:35 thorpej Exp $ */
+/* $NetBSD$ */
 
 /*
  * System call numbers.
@@ -1311,7 +1311,7 @@
 /* syscall: "__quotactl" ret: "int" args: "const char *" "struct quotactl_args *" */
 #define	SYS___quotactl	473
 
-/* syscall: "posix_spawn" ret: "int" args: "pid_t *" "const char *" "const struct posix_spawn_file_actions *" "const struct posix_spawnattr *" "char *const *" "char *const *" */
+/* syscall: "posix_spawn" ret: "int" args: "pid_t *" "const char *" "const struct posix_spawn_file_actions *" "const struct posix_spawnattr *" "const char *" "char *const *" "char *const *" */
 #define	SYS_posix_spawn	474
 
 /* syscall: "recvmmsg" ret: "int" args: "int" "struct mmsghdr *" "unsigned int" "unsigned int" "struct timespec *" */

--- a/sys/sys/syscallargs.h
+++ b/sys/sys/syscallargs.h
@@ -1,4 +1,4 @@
-/* $NetBSD: syscallargs.h,v 1.297 2020/04/26 19:16:35 thorpej Exp $ */
+/* $NetBSD$ */
 
 /*
  * System call argument lists.
@@ -3096,6 +3096,7 @@ struct sys_posix_spawn_args {
 	syscallarg(const char *) path;
 	syscallarg(const struct posix_spawn_file_actions *) file_actions;
 	syscallarg(const struct posix_spawnattr *) attrp;
+	syscallarg(const char *) wd;
 	syscallarg(char *const *) argv;
 	syscallarg(char *const *) envp;
 };


### PR DESCRIPTION
Added syscall argument support for working dir (not supported in libc). The working dir arg can be accessed in the posix_spawn function in kern_exec.c through the argument structure as "wd". do_posix_spawn will also print a test statement to make sure the os is building correctly and can be installed and tested.